### PR TITLE
Fix help page for non-int keybinds

### DIFF
--- a/rolex.py
+++ b/rolex.py
@@ -1168,7 +1168,8 @@ def generate_help_text():
     print >> help_text
     for key, (func, desc) in sorted(KEYBINDINGS.iteritems()):
         if desc:
-            print >> help_text, "  '%s'  %s" % (chr(key), desc)
+            key_str = key if isinstance(key, basestring) else chr(key)
+            print >> help_text, "  '%s'  %s" % (key_str, desc)
     return help_text.getvalue()
 
 

--- a/test_rolex.py
+++ b/test_rolex.py
@@ -5,7 +5,7 @@ import tempfile
 import textwrap
 
 from mock import Mock, patch, call, ANY
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 from rolex import Command, Pane, Watch, get_matches, get_diffs, _read_config
 from rolex import EvenVerticalLayout, EvenHorizontalLayout
@@ -562,3 +562,8 @@ def test_cmd_add_command(curses_mock):
     rolex.cmd_add_command(watch, None)
     eq_(3, len(watch.commands))
     eq_(3, len(watch.panes))
+
+
+def test_generate_help_text_returns():
+    # A little spartan, but verifies that generate_help_text returns something
+    ok_(rolex.generate_help_text())


### PR DESCRIPTION
Keyboard shortcuts like M-x would be passed through chr() and break.
